### PR TITLE
Fix typo in PInet default parameter

### DIFF
--- a/model/PInet.py
+++ b/model/PInet.py
@@ -9,7 +9,7 @@ from . import layers
 
 class Generator(nn.Module):
     def __init__(self, pano_in_channels, cube_in_channels, pano_out_channels, cube_out_channels, decoder_in_channels,
-                 decoder_out_channels, learning_type="plain", nker=64, norm="bonrm"):
+                  decoder_out_channels, learning_type="plain", nker=64, norm="bnorm"):
         super(Generator, self).__init__()
 
         self.pano_in_channels = pano_in_channels


### PR DESCRIPTION
## Summary
- fix a misspelled default norm argument in `model/PInet.py`

## Testing
- `python -m py_compile model/PInet.py`

------
https://chatgpt.com/codex/tasks/task_e_684002f58b7c832da0163b44bd8c0435