### PR TITLE
Add deterministic options and demo script

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,13 @@ pip install -r requirements.txt
 python main.py
 ```
 6. After some epochs, you can find checkpoints, log in your folder.
+
+### Demo using pretrained weights
+
+To run inference with saved weights, execute `demo.py` and specify the
+pretrained checkpoint directory and data directory containing test images
+in JSON format:
+
+```bash
+python demo.py --data_dir ./demo_data --ckpt_dir ./checkpoint_s256 --result_dir ./demo_result
+```

--- a/demo.py
+++ b/demo.py
@@ -1,0 +1,24 @@
+import argparse
+from train import test
+from utils.util import set_random_seed
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--data_dir', default='./demo_data', type=str)
+    parser.add_argument('--ckpt_dir', default='./checkpoint_s256', type=str)
+    parser.add_argument('--result_dir', default='./demo_result', type=str)
+    parser.add_argument('--log_dir', default='./demo_log', type=str)
+    parser.add_argument('--network', default='PIUnet', type=str)
+    parser.add_argument('--nker', default=32, type=int)
+    parser.add_argument('--norm', default='bnorm', type=str)
+    parser.add_argument('--seed', default=2020, type=int)
+    parser.add_argument('--data_parallel', action='store_true')
+    args = parser.parse_args()
+
+    args.mode = 'test'
+    args.lr = 1e-4
+    args.batch_size = 1
+    args.num_epoch = 1
+
+    set_random_seed(args.seed)
+    test(args)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import argparse
 
 from train import *
-torch.manual_seed(2020)
+from utils.util import set_random_seed
 ## Parser 생성하기
 
 parser = argparse.ArgumentParser()
@@ -31,9 +31,12 @@ parser.add_argument("--norm",default="bnorm",type=str,dest="norm")
 
 parser.add_argument("--network", default="PIUnet", choices=['PInet','PIUnet'], type=str, dest="network")
 
+parser.add_argument("--seed", default=2020, type=int, dest="seed")
+
 args = parser.parse_args()
 
 if __name__ == "__main__":
+    set_random_seed(args.seed)
     if args.mode == "train":
         train(args)
     elif args.mode == "test":

--- a/train.py
+++ b/train.py
@@ -6,6 +6,7 @@ from data.dataset import *
 from pre_proc.create_data import *
 from utils.util import *
 from utils.cube_to_equi import c2e
+import numpy as np
 
 import matplotlib.pyplot as plt
 from torch import autograd
@@ -14,7 +15,7 @@ from torch.utils.data import DataLoader
 
 
 def train(args):
-    torch.manual_seed(2020)
+    set_random_seed(args.seed)
     ## 트레이닝 파라메터 설정하기
     mode = args.mode
     train_continue = args.train_continue
@@ -76,10 +77,13 @@ def train(args):
         dataset_val = PanoramaDataset(in_dir=os.path.join(
             data_dir, 'val'), transform=transform_val)
 
+        worker_init = lambda worker_id: np.random.seed(args.seed + worker_id)
         loader_train = DataLoader(
-            dataset_train, batch_size=batch_size, shuffle=True, num_workers=4)
+            dataset_train, batch_size=batch_size, shuffle=True, num_workers=4,
+            worker_init_fn=worker_init)
         loader_val = DataLoader(
-            dataset_val, batch_size=batch_size, shuffle=False, num_workers=4)
+            dataset_val, batch_size=batch_size, shuffle=False, num_workers=4,
+            worker_init_fn=worker_init)
 
         # 그밖에 부수적인 variables 설정하기
         num_data_train = len(loader_train)
@@ -540,9 +544,10 @@ def train(args):
 
         writer_val.close()
         writer_train.close()
+        save_pretrained_weights(ckpt_dir, netFaceG, netCubeG)
 
 def test(args):
-    torch.manual_seed(2020)
+    set_random_seed(args.seed)
     ## test 파라메터 설정하기
     mode = args.mode
     data_parallel = args.data_parallel
@@ -599,7 +604,9 @@ def test(args):
         transform_test = transforms.Compose([Normalize(), ToTensor()])
 
         dataset_test = PanoramaDataset(in_dir=os.path.join(data_dir, 'test'), transform=transform_test)
-        loader_test = DataLoader(dataset_test, batch_size=1, shuffle=False, num_workers=1)
+        worker_init = lambda worker_id: np.random.seed(args.seed + worker_id)
+        loader_test = DataLoader(dataset_test, batch_size=1, shuffle=False, num_workers=1,
+                                worker_init_fn=worker_init)
 
         # 그밖에 부수적인 variables 설정하기
         num_data_test = len(dataset_test)

--- a/utils/util.py
+++ b/utils/util.py
@@ -1,11 +1,22 @@
 import os
 import math
+import random
 import numpy as np
 
 import cv2
 import torch
 import torch.nn as nn
 import torchvision.transforms as transforms
+
+
+def set_random_seed(seed: int = 0):
+    """Fix all random seeds for reproducibility."""
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
 
 
 def set_requires_grad(nets, requires_grad=False):
@@ -196,3 +207,12 @@ def poisson_blend(x, output, mask):
             ret.append(out)
     ret = torch.cat(ret, dim=0)
     return ret
+
+
+def save_pretrained_weights(ckpt_dir: str, netFaceG, netCubeG, filename: str = 'pretrained.pth'):
+    """Save only generator weights for inference."""
+    if not os.path.exists(ckpt_dir):
+        os.makedirs(ckpt_dir)
+    torch.save({'netFaceG': netFaceG.state_dict(),
+                'netCubeG': netCubeG.state_dict()},
+               os.path.join(ckpt_dir, filename))


### PR DESCRIPTION
## Summary
- add `set_random_seed` and `save_pretrained_weights` helpers
- use seed in `train.py` and `test()` functions
- store pretrained generator weights after training
- expose seed option in `main.py`
- provide `demo.py` for running inference with pretrained weights
- document demo usage in `README`

## Testing
- `python -m py_compile demo.py train.py main.py utils/util.py`

------
https://chatgpt.com/codex/tasks/task_e_6840064289cc832d9f8369418c89481d